### PR TITLE
NEPT-2047: Allow custom product property

### DIFF
--- a/src/Messages/Requests/CreateReviewRequest.php
+++ b/src/Messages/Requests/CreateReviewRequest.php
@@ -17,8 +17,10 @@ class CreateReviewRequest extends CreateTranslationRequest
      */
     public function __construct(Identifier $identifier, Settings $settings)
     {
+        if (empty($identifier->getProduct())) {
+            $identifier->setProduct('REV');
+        }
         parent::__construct($identifier, $settings);
-        $identifier->setProduct('REV');
     }
 
     /**

--- a/src/Messages/Requests/CreateTranslationRequest.php
+++ b/src/Messages/Requests/CreateTranslationRequest.php
@@ -32,8 +32,11 @@ class CreateTranslationRequest extends AbstractRequest
      */
     public function __construct(Identifier $identifier, Settings $settings)
     {
+        if (empty($identifier->getProduct())) {
+            $identifier->setProduct('TRA');
+        }
+
         parent::__construct($identifier, $settings);
-        $this->getIdentifier()->setProduct('TRA');
 
         if ($settings->get('client.wsdl') && $settings->get('notification.username') && $settings->get('notification.password')) {
             $this->withReturnAddress()

--- a/tests/src/Messages/Requests/CreateReviewRequestTest.php
+++ b/tests/src/Messages/Requests/CreateReviewRequestTest.php
@@ -19,6 +19,39 @@ use Symfony\Component\Yaml\Yaml;
 class CreateReviewRequestTest extends AbstractTest
 {
     /**
+     * Test default product.
+     */
+    public function testProductDefault()
+    {
+        $identifier = new Identifier();
+        $identifier->setCode('STSI')
+            ->setYear(2017)
+            ->setNumber('40017')
+            ->setVersion('0')
+            ->setPart('11');
+
+        new CreateReviewRequest($identifier, new Settings());
+        expect($identifier->getProduct())->to->equal('REV');
+    }
+
+    /**
+     * Test custom product.
+     */
+    public function testProductCustom()
+    {
+        $identifier = new Identifier();
+        $identifier->setCode('STSI')
+            ->setYear(2017)
+            ->setNumber('40017')
+            ->setVersion('0')
+            ->setPart('11')
+            ->setProduct('ABC');
+
+        new CreateReviewRequest($identifier, new Settings());
+        expect($identifier->getProduct())->to->equal('ABC');
+    }
+
+    /**
      * Test rendering.
      */
     public function testRender()

--- a/tests/src/Messages/Requests/CreateTranslationRequestTest.php
+++ b/tests/src/Messages/Requests/CreateTranslationRequestTest.php
@@ -16,6 +16,39 @@ use EC\Poetry\Tests\AbstractTest;
 class CreateTranslationRequestTest extends AbstractTest
 {
     /**
+     * Test default product.
+     */
+    public function testProductDefault()
+    {
+        $identifier = new Identifier();
+        $identifier->setCode('DGT')
+          ->setYear(2017)
+          ->setNumber('00001')
+          ->setVersion('01')
+          ->setPart('00');
+
+        new CreateTranslationRequest($identifier, new Settings());
+        expect($identifier->getProduct())->to->equal('TRA');
+    }
+
+    /**
+     * Test custom product.
+     */
+    public function testProductCustom()
+    {
+        $identifier = new Identifier();
+        $identifier->setCode('DGT')
+          ->setYear(2017)
+          ->setNumber('00001')
+          ->setVersion('01')
+          ->setPart('00')
+          ->setProduct('ABC');
+
+        new CreateTranslationRequest($identifier, new Settings());
+        expect($identifier->getProduct())->to->equal('ABC');
+    }
+
+    /**
      * Test object factories.
      */
     public function testFactories()


### PR DESCRIPTION
## NEPT-2047

### Description

Add's the ability to pass custom product id's to the translator and review requests.

### Change log

- Changed: CreateReviewRequest and CreateTranslationRequest objects to only set the product id if it is not given. Add additional test cases to support the default and custom product id's.

### Commands

Not applicable

