### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,6 +39,7 @@ matrix:
   IMAGE_PHP:
     - fpfis/httpd-php-dev:5.6
     - fpfis/httpd-php-dev:7.1
+    - fpfis/httpd-php-dev:7.2
   COMPOSER_BOUNDARY:
     - '--prefer-lowest'
     - ''

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,12 @@
         "openeuropa/code-review": "1.0.0-alpha1",
         "peridot-php/leo": "~1.6",
         "phpspec/phpspec": "~4.0@alpha",
-        "phpunit/phpunit": "~5.5|~6"
+        "phpunit/phpunit": "~5.5|~6",
+        "sebastian/comparator": ">1.2.3"
     },
+    "_readme": [
+        "We explicitly require cweagans/composer-patches to allow 'composer update --prefer-lowest' to complete successfully."
+    ],
     "suggest": {
         "monolog/monolog": "Log Poetry requests and responses via Monolog",
         "ec-europa/oe-poetry-behat": "Test Poetry service integration with Behat"

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.